### PR TITLE
Leave gzip(1) for brp-compress, inherit mkdir(1) into install(1)

### DIFF
--- a/stratis.spec
+++ b/stratis.spec
@@ -24,18 +24,15 @@ interacts with stratisd via D-Bus.
 %{__python3} setup.py build
 cd docs
 make
-gzip --stdout %{name}.8 > %{name}.8.gz
 
 %install
 %{__python3} setup.py install --skip-build --root %{buildroot}
-mkdir -p %{buildroot}%{_mandir}/man8/
-install -m 644 docs/%{name}.8.gz %{buildroot}%{_mandir}/man8/
-
+install -D -m 644 docs/%{name}.8 %{buildroot}%{_mandir}/man8/%{name}.8
 
 %files
 %{python3_sitelib}/*
 %{_bindir}/stratis
-%{_mandir}/man8/%{name}.8.gz
+%{_mandir}/man8/%{name}.8*
 %doc README.rst
 %license LICENSE
 

--- a/stratisd.spec
+++ b/stratisd.spec
@@ -19,10 +19,8 @@ A daemon that manages a block devices to create filesystems.
 cargo build --release
 
 %install
-mkdir -p %{buildroot}/%{_bindir}
-install -m 755 target/release/stratisd %{buildroot}/%{_bindir}
-mkdir -p %{buildroot}/%{_sysconfdir}/dbus-1/system.d/
-install -m 644 stratisd.conf %{buildroot}/%{_sysconfdir}/dbus-1/system.d/stratisd.conf
+install -D -m 755 target/release/stratisd %{buildroot}%{_bindir}/stratisd
+install -D -m 644 stratisd.conf %{buildroot}%{_sysconfdir}/dbus-1/system.d/stratisd.conf
 
 %files
 %{_bindir}/stratisd


### PR DESCRIPTION
  * `gzip` should be run by `brp-compress`, which might be different for different Linux distributions (e.g. other compression mechanism or no compression)
  * `install` can create the missing directory using `-D`, thus no need for a separate `mkdir` call